### PR TITLE
Release RMAS binary files

### DIFF
--- a/.github/workflows/R-CMD-check-and-Release.yml
+++ b/.github/workflows/R-CMD-check-and-Release.yml
@@ -2,11 +2,13 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*
   pull_request:
     branches:
       - master
 
-name: R-CMD-check
+name: R-CMD-check and release
 
 jobs:
   R-CMD-check:
@@ -20,9 +22,7 @@ jobs:
         config:
           - {os: windows-latest, r: 'release'}
           - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-
+          - {os: ubuntu-latest, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
@@ -33,8 +33,6 @@ jobs:
       - uses: r-lib/actions/setup-r@master
         with:
           r-version: ${{ matrix.config.r }}
-
-      - uses: r-lib/actions/setup-pandoc@master
 
       - name: Query dependencies
         run: |
@@ -58,6 +56,7 @@ jobs:
           do
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)
@@ -70,9 +69,15 @@ jobs:
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "error", check_dir = "check")
         shell: Rscript {0}
 
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - name: Build binary release
+        if: success() && startsWith(github.ref, 'refs/tags/')
+        run: devtools::build(binary = T, path = '.')
+        shell: Rscript {0}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: success() && startsWith(github.ref, 'refs/tags/')
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          files: "RMAS*"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hello @msupernaw 

This updated yml file may help add binaries releases with GitHub Actions for easy installation of RMAS 
- Summary of changes
  - Updated the R-CMD-check.yml to R-CMD-check-and-Release.yml 
  - Added latest windows, macOS, and ubuntu as targeted platforms. 
  - Added a step to build RMAS binary release if R-CMD-check runs successfully and when a tag with the v*-like name is created
  - Added a step to release binary files to RMAS release page
- How to make a release?
   $ git tag -a v0.2 -m "RMAS version 0.2"
   $ git push origin v0.2
- What are the files in a release?
  - .tgz, .zip, and .tar.gz of RMAS binary files
  - zip and tar.gz of source code
  - [Example page](https://github.com/Bai-Li-NOAA/RMAS/releases/tag/v0.2)
 - How to install RMAS in R using the released files
   - windows example: 
   ```r install.packages('https://github.com/Bai-Li-NOAA/RMAS/releases/download/v0.2/RMAS_0.1.0.zip', repos = NULL) ```




